### PR TITLE
Create extendable oauth

### DIFF
--- a/src/api/AuthApi.js
+++ b/src/api/AuthApi.js
@@ -97,10 +97,10 @@ export function flushException () {
 }
 
 
-export function googleAuth (props) {
+export function oAuth (props) {
   const query = {
-    'accessToken': props.tokenId,
-    'oAuthProvider': 'google'
+    'accessToken': props.response.tokenId,
+    'oAuthProvider': props.oAuthProvider
   }
   const options = {
     method: 'POST',

--- a/src/application/api/AbstractApi.js
+++ b/src/application/api/AbstractApi.js
@@ -40,7 +40,7 @@ export default class AbstractApi {
     flushException() {}
 
     /**
-     * Handles google OAuth
+     * Handles all OAuth
      * */
-    googleAuth() {}
+    oAuth() {}
 }

--- a/src/application/api/BackendApi.js
+++ b/src/application/api/BackendApi.js
@@ -1,5 +1,5 @@
 import AbstractApi from './AbstractApi'
-import { flushException, googleAuth, login, loginFromForm, logout, registerFromForm } from '../../api/AuthApi'
+import { flushException, oAuth, login, loginFromForm, logout, registerFromForm } from '../../api/AuthApi'
 import {fetchQuestInfo} from "../../api/QuestsApi";
 import {fetchScoreboard} from "../../api/ScoreboardApi";
 import {fetchQuestsListInfo} from "../../api/QuestsListApi";
@@ -63,9 +63,9 @@ export default class BackendApi extends AbstractApi {
      * Handles google OAuth
      * */
     //todo(toplenboren) define props
-    googleAuth(props) {
+    oAuth(props) {
         return dispatch => {
-            dispatch(googleAuth(props))
+            dispatch(oAuth(props))
         }
     }
 

--- a/src/components/Auth/Auth.jsx
+++ b/src/components/Auth/Auth.jsx
@@ -27,8 +27,8 @@ function Auth (props) {
   const title = <Title> { decodePageTitle(isInLoginMode) } </Title>
 
   const form = (isInLoginMode)
-    ? (<LoginFormTemplate exceptionDetail={ props.exceptionDetail } submitFunction={props.login} googleAuth={props.googleAuth}/>)
-    : (<RegisterFormTemplate exceptionDetail={ props.exceptionDetail } submitFunction={ props.register } googleAuth={props.googleAuth}/>)
+    ? (<LoginFormTemplate exceptionDetail={ props.exceptionDetail } submitFunction={props.login} oAuth={props.oAuth}/>)
+    : (<RegisterFormTemplate exceptionDetail={ props.exceptionDetail } submitFunction={ props.register } oAuth={props.oAuth}/>)
 
   const isInLoginChanger = (
     <a onClick={() => { setIsInLoginMode(!isInLoginMode); props.flushException() }}>
@@ -60,7 +60,7 @@ const mapDispatchToProps = dispatch => ({
   login: (username, password, rememberMe) => { dispatch(Api.loginFromForm(username, password, rememberMe)) },
   register: (username, password) => { dispatch(Api.registerFromForm(username, password)) },
   flushException: () => { dispatch(Api.flushException()) },
-  googleAuth: (response) => {dispatch(Api.googleAuth(response))}
+  oAuth: (response) => {dispatch(Api.oAuth(response))}
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(Auth)

--- a/src/components/Auth/Templates/LoginFormTemplate.jsx
+++ b/src/components/Auth/Templates/LoginFormTemplate.jsx
@@ -12,6 +12,7 @@ import { GoogleOutlined } from "@ant-design/icons";
 import { GoogleLogin } from 'react-google-login';
 //todo decide where to put GOOGLE_CLIENT_ID
 import { GOOGLE_CLIENT_ID } from '../../../settings'
+import OAuthLoginButton, {GOOGLE_AUTH} from "./OAuthLoginButton";
 
 
 export default function LoginFormTemplate (props) {
@@ -75,15 +76,7 @@ export default function LoginFormTemplate (props) {
                         Войти
           </Button>
         </Form.Item>
-          <GoogleLogin
-              clientId={GOOGLE_CLIENT_ID}
-              render={renderProps => (
-                  <Button className='oauth-button' icon={<GoogleOutlined />} onClick={renderProps.onClick} disabled={renderProps.disabled}>Войти с помощью Google</Button>
-              )}
-              buttonText="Войти с помощью Google"
-              onSuccess={props.googleAuth}
-              onFailure={props.googleAuth}
-          />
+          <OAuthLoginButton oAuth={props.oAuth} authProvider={GOOGLE_AUTH} buttonText={"Войти с помощью Google"}/>
       </Form>
     </div>
   )

--- a/src/components/Auth/Templates/OAuthLoginButton.jsx
+++ b/src/components/Auth/Templates/OAuthLoginButton.jsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+import './FormTemplate.css'
+
+import {Form, Input, Button, Checkbox, Alert} from 'antd'
+import { UserOutlined, LockOutlined } from '@ant-design/icons'
+
+import { decodeException } from './Utils'
+import PropTypes from 'prop-types'
+import { GoogleOutlined } from "@ant-design/icons";
+
+import { GoogleLogin } from 'react-google-login';
+import { GOOGLE_CLIENT_ID } from '../../../settings'
+
+export const GOOGLE_AUTH = 'google'
+//TODO(tramakarov): Add GitHub authentication
+export const GITHUB_AUTH = 'github'
+
+
+export default function OAuthLoginButton(props) {
+    switch (props.authProvider) {
+        case GOOGLE_AUTH:
+            return (
+                <GoogleLogin
+                    clientId={GOOGLE_CLIENT_ID}
+                    render={renderProps => (
+                        <Button className='oauth-button' icon={<GoogleOutlined />} onClick={renderProps.onClick} disabled={renderProps.disabled}>{props.buttonText}</Button>
+                    )}
+                    buttonText={props.buttonText}
+                    onSuccess={
+                        (response) =>
+                            props.oAuth({response: response, oAuthProvider: GOOGLE_AUTH})}
+                    onFailure={
+                        (response) =>
+                            props.oAuth({response: response, oAuthProvider: GOOGLE_AUTH})}
+                />
+            )
+    }
+}

--- a/src/components/Auth/Templates/RegisterFormTemplate.jsx
+++ b/src/components/Auth/Templates/RegisterFormTemplate.jsx
@@ -9,6 +9,7 @@ import { decodeException } from './Utils'
 import PropTypes from 'prop-types'
 import { GOOGLE_CLIENT_ID } from '../../../settings'
 import {GoogleLogin} from "react-google-login";
+import OAuthLoginButton, {GOOGLE_AUTH} from "./OAuthLoginButton";
 
 export default function RegisterFormTemplate (props) {
   const onFinish = values => {
@@ -88,15 +89,7 @@ export default function RegisterFormTemplate (props) {
                 Зарегистрироваться
             </Button>
         </Form.Item>
-          <GoogleLogin
-              clientId={GOOGLE_CLIENT_ID}
-              render={renderProps => (
-                  <Button className='oauth-button' icon={<GoogleOutlined />} onClick={renderProps.onClick} disabled={renderProps.disabled}>Регистрация с помощью Google</Button>
-              )}
-              buttonText="Войти с помощью Google"
-              onSuccess={props.googleAuth}
-              onFailure={props.googleAuth}
-          />
+          <OAuthLoginButton oAuth={props.oAuth} authProvider={GOOGLE_AUTH} buttonText={"Регистрация с помощью Google"}/>
       </Form>
     </div>
   )


### PR DESCRIPTION
**How to add new OAuth button:**
1. Define constant in OAuthLoginButton: `{OAuth provider}_LOGIN = '{OAuth provider in lower case}'`
2. Add case for defined constant in `function OAuthLoginButton` with button react component
3. Add new button in `RegisterFormTemplate` and `LoginFormTemplate` by inserting string
> `<OAuthLoginButton oAuth={props.oAuth} authProvider={constant defined at step 1} buttonText={text for button}/>`